### PR TITLE
PLT-1227 removed development mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,8 +204,8 @@ Default: `[]`
 
 | Name | Description |
 |------|-------------|
-| <a name="output_domain"></a> [domain](#output\_domain) | Current zone information. |
 | <a name="output_rules"></a> [rules](#output\_rules) | Created Cloudflare rules for the current zone. |
+| <a name="output_zone"></a> [zone](#output\_zone) | Current zone information. |
 
 <!-- TFDOCS_OUTPUTS_END -->
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,6 +1,6 @@
-output "domain" {
+output "zone" {
   description = "Current zone information."
-  value       = data.cloudflare_zones.domain.result
+  value       = { for k, v in data.cloudflare_zones.domain.result[0] : k => v if k != "development_mode" }
 }
 
 output "rules" {


### PR DESCRIPTION
PLT-1227 removed development mode from the output since it is creating diff in the every plan. It is tracking the time since the last enabled/disabled of the development mode in the zone settings. 