### PR TITLE
Plt 1389 account level WAF rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,12 +39,6 @@ This Terraform module manages Cloudflare Rulesets.
 
 The following input variables are required:
 
-### <a name="input_domain"></a> [domain](#input\_domain)
-
-Description: Cloudflare domain to apply rules for.
-
-Type: `string`
-
 ### <a name="input_name"></a> [name](#input\_name)
 
 Description: Name of the ruleset.
@@ -67,9 +61,25 @@ Type: `string`
 
 The following input variables are optional (have default values):
 
+### <a name="input_domain"></a> [domain](#input\_domain)
+
+Description: Cloudflare domain to apply rules for. Required for zone-level rulesets.
+
+Type: `string`
+
+Default: `null`
+
 ### <a name="input_ref_prefix"></a> [ref\_prefix](#input\_ref\_prefix)
 
 Description: Prefix to add to the rule references.
+
+Type: `string`
+
+Default: `null`
+
+### <a name="input_account_id"></a> [account\_id](#input\_account\_id)
+
+Description: Cloudflare account ID. Required for account-level rulesets.
 
 Type: `string`
 
@@ -211,7 +221,7 @@ Default: `[]`
 | Name | Description |
 |------|-------------|
 | <a name="output_rules"></a> [rules](#output\_rules) | Created Cloudflare rules for the current zone. |
-| <a name="output_zone"></a> [zone](#output\_zone) | Current zone information. |
+| <a name="output_zone"></a> [zone](#output\_zone) | Current zone information. Only available for zone-level rulesets. |
 
 <!-- TFDOCS_OUTPUTS_END -->
 

--- a/data.tf
+++ b/data.tf
@@ -1,3 +1,4 @@
 data "cloudflare_zones" "this" {
-  name = var.domain
+  count = var.kind == "zone" ? 1 : 0
+  name  = var.domain
 }

--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,6 @@
 resource "cloudflare_ruleset" "this" {
-  zone_id     = lookup(data.cloudflare_zones.this.result[0], "id")
+  account_id  = var.kind == "account" ? var.account_id : null
+  zone_id     = var.kind == "zone" ? lookup(data.cloudflare_zones.this[0].result[0], "id") : null
   name        = var.name
   kind        = var.kind
   phase       = var.phase

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,6 +1,6 @@
 output "zone" {
-  description = "Current zone information."
-  value       = { for k, v in data.cloudflare_zones.this.result[0] : k => v if k != "development_mode" }
+  description = "Current zone information. Only available for zone-level rulesets."
+  value       = var.kind == "zone" ? { for k, v in data.cloudflare_zones.this[0].result[0] : k => v if k != "development_mode" } : null
 }
 
 output "rules" {

--- a/variables.tf
+++ b/variables.tf
@@ -1,6 +1,7 @@
 variable "domain" {
-  description = "Cloudflare domain to apply rules for."
+  description = "Cloudflare domain to apply rules for. Required for zone-level rulesets."
   type        = string
+  default     = null
 }
 
 variable "name" {
@@ -14,6 +15,12 @@ variable "ref_prefix" {
   default     = null
 }
 
+variable "account_id" {
+  description = "Cloudflare account ID. Required for account-level rulesets."
+  type        = string
+  default     = null
+}
+
 variable "kind" {
   description = "Type of Ruleset to create."
   type        = string
@@ -21,8 +28,8 @@ variable "kind" {
   # Ensure we specify only the supported kind values
   # https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/ruleset#kind
   validation {
-    condition     = can(contains(["zone"], var.kind))
-    error_message = "Only the following kind types are allowed: zone."
+    condition     = can(contains(["zone", "account"], var.kind))
+    error_message = "Only the following kind types are allowed: zone, account."
   }
 }
 


### PR DESCRIPTION
Instead of creating rules at Zone level, we now do it at Account to reduce duplication and make it easier

Schema: https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/ruleset#schema 